### PR TITLE
Ptw/deserialize macro

### DIFF
--- a/src/form_struct.rs
+++ b/src/form_struct.rs
@@ -1,0 +1,23 @@
+#[macro_export]
+macro_rules! form_struct {
+    (#[derive( $($derive_attributes:path),* $(,)?)] $vis:vis struct $struct_name:ident { $($field:ident($rename:expr): $typ:ty),+ $(,)?}) => {
+        #[allow(non_snake_case)]
+        $vis mod $struct_name {
+            #[allow(unused_imports)]
+            use serde::Deserialize;
+
+            #[derive($($derive_attributes, )*)]
+            $vis struct Form {
+                $(#[serde(rename = $rename)]
+                $vis $field: $typ,)+
+            }
+
+            $($vis fn $field() -> &'static str { $rename })+
+
+            #[derive(Default)]
+            $vis struct Errors {
+                $($vis $field: Option<&'static str>,)+
+            }
+        }
+    };
+}

--- a/src/form_struct.rs
+++ b/src/form_struct.rs
@@ -1,6 +1,10 @@
 #[macro_export]
 macro_rules! form_struct {
-    (#[derive( $($derive_attributes:path),* $(,)?)] $vis:vis struct $struct_name:ident { $($field:ident($rename:expr): $typ:ty),+ $(,)?}) => {
+    (#[derive( $($derive_attributes:path),* $(,)?)]
+     $vis:vis struct $struct_name:ident {
+         $( $(#[$field_macro:tt($($params:path),* $(,)?)])*
+         $field:ident($rename:expr): $typ:ty),+ $(,)?
+     }) => {
         #[allow(non_snake_case)]
         $vis mod $struct_name {
             #[allow(unused_imports)]
@@ -8,6 +12,7 @@ macro_rules! form_struct {
 
             #[derive($($derive_attributes, )*)]
             $vis struct Form {
+                $($(#[$field_macro($($params,)*)])*)*
                 $(#[serde(rename = $rename)]
                 $vis $field: $typ,)+
             }

--- a/src/html_views.rs
+++ b/src/html_views.rs
@@ -17,9 +17,8 @@ use maud::DOCTYPE;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::hx_triggers::form_struct;
-use crate::hx_triggers::ContactsInteraction;
-use crate::hx_triggers::DeleteTrigger;
+use crate::form_struct;
+use crate::hx_trigger_variants;
 use crate::model::Contact;
 use crate::model::ContactId;
 use crate::model::PendingContact;
@@ -65,6 +64,8 @@ pub struct GetContactsParams {
     page("page"): Option<u32>,
 }
 );
+
+hx_trigger_variants!(ContactsInteraction { Search: "search" });
 
 #[derive(Deserialize, TypedPath)]
 #[typed_path("/contacts")]
@@ -488,6 +489,10 @@ pub fn edit_contact_form(
         flashes,
     )
 }
+
+hx_trigger_variants!(DeleteTrigger {
+    Button: "delete-btn"
+});
 
 pub async fn contacts_delete(
     ViewContact { id: contact_id }: ViewContact,

--- a/src/html_views.rs
+++ b/src/html_views.rs
@@ -117,7 +117,7 @@ pub async fn contacts(
         @for contact in contacts {
             tr {
                 td {
-                    input type="checkbox" name="selected_contact_ids" value=(contact.id) x-model="selected" {}
+                    input type="checkbox" name=(DeleteContactList::selected_contact_ids()) value=(contact.id) x-model="selected" {}
                 }
                 td { (contact.first_name)}
                 td { (contact.last_name)}
@@ -453,7 +453,7 @@ pub fn edit_contact_form(
                     legend { "Contact Values" }
                     p {
                         label for="email" {"Email"}
-                        input name="email_address" id="email" type="email"
+                        input name=(PendingContact::email_address()) id="email" type="email"
                         hx-get=(ContactEmail{id})
                         hx-target="next .error"
                         hx-trigger="change, keyup delay:200ms changed"
@@ -462,17 +462,17 @@ pub fn edit_contact_form(
                     }
                     p {
                         label for="first_name" {"First Name"}
-                        input name="first_name" id="first_name" type="text" placeholder="First Name" value=(contact.first_name.unwrap_or_default());
+                        input name=(PendingContact::first_name()) id="first_name" type="text" placeholder="First Name" value=(contact.first_name.unwrap_or_default());
                         span .error {(errors.first_name.unwrap_or_default())}
                     }
                     p {
                         label for="last_name" {"Last Name"}
-                        input name="last_name" id="last_name" type="text" placeholder="Last Name" value=(contact.last_name.unwrap_or_default());
+                        input name=(PendingContact::last_name()) id="last_name" type="text" placeholder="Last Name" value=(contact.last_name.unwrap_or_default());
                         span .error {(errors.last_name.unwrap_or_default())}
                     }
                     p {
                         label for="phone" {"Phone"}
-                        input name="phone" id="phone" type="text" placeholder="Phone" value=(contact.phone.unwrap_or_default());
+                        input name=(PendingContact::phone()) id="phone" type="text" placeholder="Phone" value=(contact.phone.unwrap_or_default());
                         span .error {(errors.phone.unwrap_or_default())}
                     }
                     button {"Save"}
@@ -521,10 +521,13 @@ pub async fn contacts_delete(
     }
 }
 
+// Use the full path for `ContactId` because we need to put it in the `mod`'s scope.
+form_struct! {
 #[derive(Deserialize)]
 pub struct DeleteContactList {
     #[serde(default)]
-    pub selected_contact_ids: Vec<ContactId>,
+    selected_contact_ids("selected_contact_ids"): Vec<crate::model::ContactId>,
+}
 }
 
 // This is already at the `Contacts` page,
@@ -538,7 +541,7 @@ pub async fn contacts_delete_all(
     _: Contacts,
     State(state): State<AppState>,
     flash: Flash,
-    Form(to_delete): Form<DeleteContactList>,
+    Form(to_delete): Form<DeleteContactList::Form>,
 ) -> Result<Response<Body>, AppError> {
     let connection = state.db_pool.get().await?;
     connection

--- a/src/html_views.rs
+++ b/src/html_views.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use axum::body::Body;
 use axum::extract::Query;
 use axum::extract::State;
@@ -236,7 +234,11 @@ pub async fn contacts_count(
 pub struct AddContact;
 
 pub async fn contacts_new_get(_: AddContact, flashes: IncomingFlashes) -> impl IntoResponse {
-    new_contact_form(PendingContact::Form::default(), HashMap::new(), flashes)
+    new_contact_form(
+        PendingContact::Form::default(),
+        PendingContact::Errors::default(),
+        flashes,
+    )
 }
 
 pub async fn contacts_new_post(
@@ -271,12 +273,12 @@ pub async fn contacts_new_post(
 
 pub fn new_contact_form(
     contact: PendingContact::Form,
-    errors: HashMap<&str, String>,
+    errors: PendingContact::Errors,
     flashes: IncomingFlashes,
 ) -> impl IntoResponse {
     fn contact_form(
         contact: PendingContact::Form,
-        errors: HashMap<&str, String>,
+        errors: PendingContact::Errors,
     ) -> maud::PreEscaped<String> {
         let body = html! {
             form action=(AddContact) method="post" {
@@ -285,22 +287,22 @@ pub fn new_contact_form(
                     p {
                         label for="email" {"Email"}
                         input name=(PendingContact::email_address()) id="email" type="email" placeholder="Email" value=(contact.email_address.unwrap_or_default());
-                        span .error {(errors.get("email").map(String::as_str).unwrap_or_default())}
+                        span .error {(errors.email_address.unwrap_or_default())}
                     }
                     p {
                         label for="first_name" {"First Name"}
                         input name=(PendingContact::first_name()) id="first_name" type="text" placeholder="First Name" value=(contact.first_name.unwrap_or_default());
-                        span .error {(errors.get("first").map(String::as_str).unwrap_or_default())}
+                        span .error {(errors.first_name.unwrap_or_default())}
                     }
                     p {
                         label for="last_name" {"Last Name"}
                         input name=(PendingContact::last_name()) id="last_name" type="text" placeholder="Last Name" value=(contact.last_name.unwrap_or_default());
-                        span .error {(errors.get("last").map(String::as_str).unwrap_or_default())}
+                        span .error {(errors.last_name.unwrap_or_default())}
                     }
                     p {
                         label for="phone" {"Phone"}
                         input name=(PendingContact::phone()) id="phone" type="text" placeholder="Phone" value=(contact.phone.unwrap_or_default());
-                        span .error {(errors.get("phone").map(String::as_str).unwrap_or_default())}
+                        span .error {(errors.phone.unwrap_or_default())}
                     }
                     button {"Save"}
                 }
@@ -396,7 +398,13 @@ pub async fn contacts_edit_get(
             .into_response();
     }
     let contact = contact.unwrap();
-    edit_contact_form(id, contact.into(), HashMap::new(), flashes).into_response()
+    edit_contact_form(
+        id,
+        contact.into(),
+        PendingContact::Errors::default(),
+        flashes,
+    )
+    .into_response()
 }
 
 pub async fn contacts_edit_post(
@@ -434,7 +442,7 @@ pub async fn contacts_edit_post(
 pub fn edit_contact_form(
     id: ContactId,
     contact: PendingContact::Form,
-    errors: HashMap<&str, String>,
+    errors: PendingContact::Errors,
     flashes: IncomingFlashes,
 ) -> impl IntoResponse {
     page(
@@ -449,22 +457,22 @@ pub fn edit_contact_form(
                         hx-target="next .error"
                         hx-trigger="change, keyup delay:200ms changed"
                         placeholder="Email" value=(contact.email_address.unwrap_or_default());
-                        span .error {(errors.get("email").map(String::as_str).unwrap_or_default())}
+                        span .error {(errors.email_address.unwrap_or_default())}
                     }
                     p {
                         label for="first_name" {"First Name"}
                         input name="first_name" id="first_name" type="text" placeholder="First Name" value=(contact.first_name.unwrap_or_default());
-                        span .error {(errors.get("first").map(String::as_str).unwrap_or_default())}
+                        span .error {(errors.first_name.unwrap_or_default())}
                     }
                     p {
                         label for="last_name" {"Last Name"}
                         input name="last_name" id="last_name" type="text" placeholder="Last Name" value=(contact.last_name.unwrap_or_default());
-                        span .error {(errors.get("last").map(String::as_str).unwrap_or_default())}
+                        span .error {(errors.last_name.unwrap_or_default())}
                     }
                     p {
                         label for="phone" {"Phone"}
                         input name="phone" id="phone" type="text" placeholder="Phone" value=(contact.phone.unwrap_or_default());
-                        span .error {(errors.get("phone").map(String::as_str).unwrap_or_default())}
+                        span .error {(errors.phone.unwrap_or_default())}
                     }
                     button {"Save"}
                 }

--- a/src/hx_triggers.rs
+++ b/src/hx_triggers.rs
@@ -18,6 +18,7 @@ macro_rules! form_struct {
 
             $($vis fn $field() -> &'static str { $rename })+
 
+            #[derive(Default)]
             $vis struct Errors {
                 $($vis $field: Option<&'static str>,)+
             }

--- a/src/hx_triggers.rs
+++ b/src/hx_triggers.rs
@@ -1,33 +1,10 @@
 use axum::http::HeaderName;
-use axum::http::HeaderValue;
 
-static HX_TRIGGER: HeaderName = HeaderName::from_static("hx-trigger");
+pub(crate) static HX_TRIGGER: HeaderName = HeaderName::from_static("hx-trigger");
 
-macro_rules! form_struct {
-    (#[derive( $($derive_attributes:path),* $(,)?)] $vis:vis struct $struct_name:ident { $($field:ident($rename:expr): $typ:ty),+ $(,)?}) => {
-        #[allow(non_snake_case)]
-        $vis mod $struct_name {
-            #[allow(unused_imports)]
-            use serde::Deserialize;
-
-            #[derive($($derive_attributes, )*)]
-            $vis struct Form {
-                $(#[serde(rename = $rename)]
-                $vis $field: $typ,)+
-            }
-
-            $($vis fn $field() -> &'static str { $rename })+
-
-            #[derive(Default)]
-            $vis struct Errors {
-                $($vis $field: Option<&'static str>,)+
-            }
-        }
-    };
-}
-
-pub(crate) use form_struct;
-
+// Could put enum declaration outside of macro if more methods are needed.
+// That would mean that we duplicate the variants.
+#[macro_export]
 macro_rules! hx_trigger_variants {
     ($enum_name:ident { $($variant:ident: $id:expr),+ }) => {
         pub enum $enum_name {
@@ -43,13 +20,13 @@ macro_rules! hx_trigger_variants {
 
         impl axum_extra::headers::Header for $enum_name {
             fn name() -> &'static axum::http::HeaderName {
-                &HX_TRIGGER
+                &$crate::hx_triggers::HX_TRIGGER
             }
 
             fn decode<'i, I>(values: &mut I) -> Result<Self, axum_extra::headers::Error>
             where
                 Self: Sized,
-                I: Iterator<Item = &'i HeaderValue>,
+                I: Iterator<Item = &'i axum::http::HeaderValue>,
             {
                 let value = values
                     .next()
@@ -61,18 +38,11 @@ macro_rules! hx_trigger_variants {
                 return Err(axum_extra::headers::Error::invalid())
             }
 
-            fn encode<E: Extend<HeaderValue>>(&self, values: &mut E) {
+            fn encode<E: Extend<axum::http::HeaderValue>>(&self, values: &mut E) {
                 let s = self.id();
-                let value = HeaderValue::from_static(s);
+                let value = axum::http::HeaderValue::from_static(s);
                 values.extend(std::iter::once(value));
             }
         }
     }
 }
-
-// Could put enum declaration outside of macro if more methods are needed.
-// That would mean that we duplicate the variants.
-hx_trigger_variants!(ContactsInteraction { Search: "search" });
-hx_trigger_variants!(DeleteTrigger {
-    Button: "delete-btn"
-});

--- a/src/hx_triggers.rs
+++ b/src/hx_triggers.rs
@@ -6,7 +6,9 @@ pub(crate) static HX_TRIGGER: HeaderName = HeaderName::from_static("hx-trigger")
 // That would mean that we duplicate the variants.
 #[macro_export]
 macro_rules! hx_trigger_variants {
-    ($enum_name:ident { $($variant:ident: $id:expr),+ }) => {
+    ($enum_name:ident {
+        $($variant:ident: $id:expr),+
+    }) => {
         pub enum $enum_name {
             $($variant,)+
         }

--- a/src/hx_triggers.rs
+++ b/src/hx_triggers.rs
@@ -5,7 +5,7 @@ use serde::Deserialize;
 static HX_TRIGGER: HeaderName = HeaderName::from_static("hx-trigger");
 
 macro_rules! form_struct {
-    (( $($derive_attributes:ident, )*) struct $struct_name:ident { $($field:ident: $rename:literal,)+ }) => {
+    (#[derive( $($derive_attributes:ident),* $(,)?)] struct $struct_name:ident { $($field:ident: $rename:expr),+ $(,)?}) => {
         #[derive($($derive_attributes, )*)]
         pub struct $struct_name {
             $(#[serde(rename = $rename)]
@@ -64,8 +64,9 @@ hx_trigger_variants!(DeleteTrigger {
 });
 
 form_struct!(
-    (Debug, Deserialize,)
+    #[derive(Debug, Deserialize,)]
     struct Test {
         string: "q",
+        other: "other",
     }
 );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,10 +2,11 @@ use axum::response::IntoResponse;
 use deadpool_diesel::postgres::Pool;
 
 pub mod api;
+pub(crate) mod form_struct;
 pub mod html_views;
-pub mod hx_triggers;
-pub mod model;
-pub mod schema;
+pub(crate) mod hx_triggers;
+pub(crate) mod model;
+pub(crate) mod schema;
 
 #[derive(Clone)]
 pub struct AppState {

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,14 +14,17 @@ use tower_http::services::ServeDir;
 // TODO:
 // - [ ] try using `serde(try_from = "...")` with contacts and user facing contacts.
 //   want to report multiple errors and for errors to be user-facing
+//   Maybe want to use macro for this?
 // - [ ] test with forms (in the style of zero to prod in rust)
 // - [ ] test with playwright
-// - [ ] shift to use mvc (with state extract for contacts as model?)
 // - [ ] include tracing with per-request correlation id
 // - [x] provide extract for hx-trigger id
 // - [x] add macro for hx-trigger id
 // - [x] separate out database from html_views
 //       - Can wait to do this later, rust-analyzer makes it easy to extract to variable and then to function.
+// - [ ] shift to use mvc (with state extract for contacts as model?)
+//       - It is nice to be able to move quickly without the separation. Maybe we separate out if too complicated?
+//         But could also separate into components if too complicated.
 // - [ ] style with tailwind
 //       - https://www.crocodile.dev/blog/css-transitions-with-tailwind-and-htmx
 //       - https://tailwindcss.com/docs/plugins#adding-variants

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,12 +12,13 @@ use hypermedia_systems_rust::AppState;
 use tower_http::services::ServeDir;
 
 // TODO:
-// - [ ] try using `serde(try_from = "...")` with contacts and user facing contacts.
-//   want to report multiple errors and for errors to be user-facing
-//   Maybe want to use macro for this?
 // - [ ] test with forms (in the style of zero to prod in rust)
 // - [ ] test with playwright
 // - [ ] include tracing with per-request correlation id
+// - [x] try using `serde(try_from = "...")` with contacts and user facing contacts.
+//   want to report multiple errors and for errors to be user-facing
+//   Maybe want to use macro for this?
+//    -> don't actually want macro since want to emphasize going from unknown to valid
 // - [x] provide extract for hx-trigger id
 // - [x] add macro for hx-trigger id
 // - [x] separate out database from html_views

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::fmt::Display;
 
 use diesel::query_builder::AsChangeset;
@@ -64,7 +63,7 @@ impl From<Contact> for PendingContact::Form {
 }
 
 impl PendingContact::Form {
-    pub fn to_valid(&self) -> Result<NewContact, HashMap<&'static str, String>> {
+    pub fn to_valid(&self) -> Result<NewContact, PendingContact::Errors> {
         match (
             &self.first_name,
             &self.last_name,
@@ -80,21 +79,21 @@ impl PendingContact::Form {
                 })
             }
             _ => {
-                let mut errors = HashMap::new();
+                let mut errors = PendingContact::Errors::default();
 
                 if self.first_name.is_none() {
-                    errors.insert("first", "Missing first name".into());
+                    errors.first_name = Some("Missing first name");
                 }
                 if self.last_name.is_none() {
-                    errors.insert("last", "Missing last name".into());
+                    errors.last_name = Some("Missing last name");
                 }
                 if self.phone.is_none() {
-                    errors.insert("phone", "Missing phone".into());
+                    errors.phone = Some("Missing phone");
                 }
                 if self.email_address.is_none()
                     || self.email_address.as_ref().is_some_and(|s| s.is_empty())
                 {
-                    errors.insert("email", "Missing email address".into());
+                    errors.email_address = Some("Missing email address");
                 }
 
                 Err(errors)

--- a/src/model.rs
+++ b/src/model.rs
@@ -9,6 +9,8 @@ use diesel_derive_newtype::DieselNewType;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::hx_triggers::form_struct;
+
 #[derive(DieselNewType, Clone, Copy, Debug, Deserialize, Default, Serialize, PartialEq, Eq)]
 #[serde(transparent)]
 pub struct ContactId(i32);
@@ -30,20 +32,15 @@ pub struct Contact {
     pub email_address: String,
 }
 
-/// Pending contact that is the information entered by the user. Could be
-/// missing fields or have invalid fields (eg, bogus email address format).
-/// Could experiment with just using a HashMap for the next endpoint.
-#[derive(Deserialize, Default, Debug, Clone)]
+form_struct!(
+#[derive(serde::Deserialize, Default, Debug, Clone)]
 pub struct PendingContact {
-    #[serde(deserialize_with = "non_empty_str")]
-    pub first_name: Option<String>,
-    #[serde(deserialize_with = "non_empty_str")]
-    pub last_name: Option<String>,
-    #[serde(deserialize_with = "non_empty_str")]
-    pub phone: Option<String>,
-    #[serde(deserialize_with = "non_empty_str")]
-    pub email_address: Option<String>,
+     first_name("first_name"): Option<String>,
+     last_name("last_name"): Option<String>,
+     phone("phonee"): Option<String>,
+     email_address("email_address"): Option<String>,
 }
+);
 
 #[derive(Insertable, AsChangeset, Deserialize)]
 #[diesel(table_name = crate::schema::contacts)]
@@ -55,15 +52,7 @@ pub struct NewContact {
     pub email_address: String,
 }
 
-pub(crate) fn non_empty_str<'de, D: serde::Deserializer<'de>>(
-    d: D,
-) -> Result<Option<String>, D::Error> {
-    use serde::Deserialize;
-    let o: Option<String> = Option::deserialize(d)?;
-    Ok(o.filter(|s| !s.is_empty()))
-}
-
-impl From<Contact> for PendingContact {
+impl From<Contact> for PendingContact::Form {
     fn from(value: Contact) -> Self {
         Self {
             first_name: Some(value.first_name),
@@ -74,7 +63,7 @@ impl From<Contact> for PendingContact {
     }
 }
 
-impl PendingContact {
+impl PendingContact::Form {
     pub fn to_valid(&self) -> Result<NewContact, HashMap<&'static str, String>> {
         match (
             &self.first_name,

--- a/src/model.rs
+++ b/src/model.rs
@@ -8,7 +8,7 @@ use diesel_derive_newtype::DieselNewType;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::hx_triggers::form_struct;
+use crate::form_struct;
 
 #[derive(DieselNewType, Clone, Copy, Debug, Deserialize, Default, Serialize, PartialEq, Eq)]
 #[serde(transparent)]


### PR DESCRIPTION
Add a macro to generate a struct to represent a form. Handles creating a nested Form and Errors struct within a module, as well as creating functions for the field names. Updates all of the forms to use the associated field name functions.